### PR TITLE
Feature/update output

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,5 +248,6 @@ No modules.
 | <a name="output_container_app_fqdn"></a> [container\_app\_fqdn](#output\_container\_app\_fqdn) | The FQDN of the created Container App |
 | <a name="output_container_app_id"></a> [container\_app\_id](#output\_container\_app\_id) | The ID of the created Container App |
 | <a name="output_container_app_name"></a> [container\_app\_name](#output\_container\_app\_name) | The name of the created Container App |
+| <a name="output_container_app_principal_id"></a> [container\_app\_principal\_id](#output\_container\_app\_principal\_id) | The Principal ID of the Container App's Managed Identity |
 | <a name="output_container_rg_name"></a> [container\_rg\_name](#output\_container\_rg\_name) | The name of the created RG |
 <!-- END_TF_DOCS -->

--- a/output.tf
+++ b/output.tf
@@ -27,3 +27,8 @@ output "container_app_fqdn" {
   description = "The FQDN of the created Container App"
   value       = var.create_container_app ? azurerm_container_app.container_app[0].ingress[0].fqdn : null
 }
+
+output "container_app_principal_id" {
+  description = "The Principal ID of the Container App's Managed Identity"
+  value       = var.create_container_app && var.container_app_identity != null ? azurerm_container_app.container_app[0].identity[0].principal_id : null
+}


### PR DESCRIPTION
This pull request includes changes to add a new output for the Container App's Managed Identity Principal ID. The most important changes are the addition of the `container_app_principal_id` output in both the `README.md` and `output.tf` files.

### Documentation Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R251): Added a new entry for `container_app_principal_id` to document the Principal ID of the Container App's Managed Identity.

### Terraform Configuration:
* [`output.tf`](diffhunk://#diff-d198a7806a6d934073bbf32ec6cc45d99aaac1e0ae9b1d46055ab433621e2035R30-R34): Added a new output `container_app_principal_id` to capture the Principal ID of the Container App's Managed Identity.