### PR TITLE
Use version 4.x

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Use version 4.x

## 🤔 Why

Otherwise we are pinned against "3.108.x" and we are forced to use a older version. 

